### PR TITLE
Fix discountCard being required and change qty in order root to totalQty

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "graphql-yoga": "^1.14.6",
     "mongoose": "^5.1.4",
-    "nodemon": "^1.17.5"
+    "nodemon": "^1.17.5",
+    "signale": "^1.1.0"
   }
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,3 +1,4 @@
+const signale = require('signale');
 const { GraphQLServer } = require('graphql-yoga');
 const mongoose = require('mongoose');
 
@@ -77,5 +78,5 @@ const server = new GraphQLServer({
   resolvers
 });
 mongoose.connect(uri);
-mongoose.connection.once('open', () => console.log('Connected to MongoDB'));
-server.start(() => console.log('GraphQL server on localhost:4000'));
+mongoose.connection.once('open', () => signale.success('Connected to MongoDB'));
+server.start(() => signale.success('GraphQL server on localhost:4000'));

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -33,7 +33,7 @@ const resolvers = {
         name: args.name,
         remark: args.remark,
         menuItems: JSON.parse(args.menuItems)[0],
-        qty: args.qty,
+        totalQty: args.totalQty,
         discountCards: args.discountCards,
         total: args.total,
         orderedAt: setTime(),
@@ -58,7 +58,7 @@ const resolvers = {
 
         update.menuItems = JSON.parse(args.menuItems)[0];
         update.total = args.total;
-        update.qty = args.qty;
+        update.totalQty = args.totalQty;
       }
 
       if (args.discountCards) {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -52,9 +52,9 @@ const resolvers = {
       }
 
       if (args.menuItems) {
-        // If menuItems are updated, total and qty may change
-        if (!args.qty)
-          throw `args.qty and args.total is required to update menuItems`;
+        // If menuItems are updated, total and totalQty may change
+        if (!args.totalQty || !args.total)
+          throw `args.totalQty and args.total is required to update menuItems`;
 
         update.menuItems = JSON.parse(args.menuItems)[0];
         update.total = args.total;

--- a/server/src/models/order.js
+++ b/server/src/models/order.js
@@ -7,7 +7,7 @@ const orderSchema = new Schema({
   name: { type: String, required: true },
   remark: String,
   menuItems: { type: Array, required: true },
-  qty: { type: Number, required: true },
+  totalQty: { type: Number, required: true },
   discountCards: Number,
   total: { type: Number, required: true },
   orderedAt: { type: String, required: true },

--- a/server/src/models/order.js
+++ b/server/src/models/order.js
@@ -8,7 +8,7 @@ const orderSchema = new Schema({
   remark: String,
   menuItems: { type: Array, required: true },
   qty: { type: Number, required: true },
-  discountCards: { type: Number, required: true },
+  discountCards: Number,
   total: { type: Number, required: true },
   orderedAt: { type: String, required: true },
   scannedAt: String,

--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -12,7 +12,7 @@ type Mutation {
     name: String!
     remark: String
     menuItems: String!
-    qty: Int!
+    totalQty: Int!
     discountCards: Int
     total: Float!
   ): Order!
@@ -21,7 +21,7 @@ type Mutation {
     name: String
     remark: String
     menuItems: String
-    qty: Int
+    totalQty: Int
     discountCards: Int
     total: Float
     tableNumber: String
@@ -41,7 +41,7 @@ type Order {
   name: String!
   remark: String
   menuItems: [OrderedItem!]!
-  qty: Int!
+  totalQty: Int!
   tableNumber: String
   discountCards: Int
   total: Float!

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -418,7 +418,7 @@ capture-stack-trace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
-chalk@^2.0.1:
+chalk@^2.0.1, chalk@^2.3.2:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -669,6 +669,12 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
+error-ex@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  dependencies:
+    is-arrayish "^0.2.1"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -790,6 +796,12 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -810,6 +822,12 @@ finalhandler@1.1.1:
     parseurl "~1.3.2"
     statuses "~1.4.0"
     unpipe "~1.0.0"
+
+find-up@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -1156,6 +1174,10 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -1332,6 +1354,10 @@ js-yaml@^3.10.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+
 kareem@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.1.0.tgz#d63197b57311830e4ceb3f34431f22f2de826a03"
@@ -1361,6 +1387,22 @@ latest-version@^3.0.0:
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
   dependencies:
     package-json "^4.0.0"
+
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 lodash.assign@^4.2.0:
   version "4.2.0"
@@ -1722,6 +1764,22 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  dependencies:
+    p-try "^1.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
 package-json@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
@@ -1730,6 +1788,13 @@ package-json@^4.0.0:
     registry-auth-token "^3.0.1"
     registry-url "^3.0.3"
     semver "^5.1.0"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parseurl@~1.3.2:
   version "1.3.2"
@@ -1742,6 +1807,10 @@ pascalcase@^0.1.1:
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -1768,6 +1837,13 @@ pause-stream@0.0.11:
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
+pkg-conf@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-2.1.0.tgz#2126514ca6f2abfebd168596df18ba57867f0058"
+  dependencies:
+    find-up "^2.0.0"
+    load-json-file "^4.0.0"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -2057,6 +2133,14 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+signale@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/signale/-/signale-1.1.0.tgz#b2f6d20f09df83c07fe18a968260b628f9d3f0f8"
+  dependencies:
+    chalk "^2.3.2"
+    figures "^2.0.0"
+    pkg-conf "^2.1.0"
+
 sliced@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/sliced/-/sliced-0.0.5.tgz#5edc044ca4eb6f7816d50ba2fc63e25d8fe4707f"
@@ -2198,6 +2282,10 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
 strip-eof@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The `discountCard` value was being required while creating an order as it was set to be required inside the Mongoose model, when in the GraphQL schema it wasn't required.

Changed `qty` inside the `Order` type to `totalQty` to make a distinction between `qty` inside `menuItems` as requested by @is343.